### PR TITLE
Upgrade signet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem 'signet', '~> 0.4.5'
-gem 'curb-fu', '~> 0.6.2'
 gemspec
 
 group :development, :test do

--- a/lib/maxcdn/version.rb
+++ b/lib/maxcdn/version.rb
@@ -1,3 +1,3 @@
 module MaxCDN
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/maxcdn.gemspec
+++ b/maxcdn.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |gem|
   gem.email = "joshua@mervine.net"
   gem.authors = ["Joshua P. Mervine"]
   gem.add_dependency 'json' if RUBY_VERSION.start_with? "1.8"
-  gem.add_dependency 'signet', '~> 0.4.5'
+  gem.add_dependency 'signet', '~> 0.5.1'
   gem.add_dependency 'curb-fu', '~> 0.6.2'
 end


### PR DESCRIPTION
This updates the usage of the signet gem to allow for use with the faraday 0.9.x series. I also bumped the version number to 0.2.0. All tests are passing but it's probably worth running this somewhere that it can really be tested.