### PR TITLE
Replace curb-fu with faraday.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require 'maxcdn'
 api = MaxCDN::Client.new("myalias", "consumer_key", "consumer_secret")
 
 ####
-# Turn on debugging for underlying Curl::Easy and CurbFu modules
+# Turn on debugging outputs
 #
 # api.debug = true
 
@@ -97,6 +97,15 @@ bundle exec ruby ./test/integration.rb # requires host's IP be whitelisted
 ```
 
 # Change Log
+
+##### 0.3.0
+
+* Replace CurbFu with Faraday (#10).
+
+##### 0.2.1
+
+* Upgrade signet gem to allow for use with the faraday 0.9.x series (#7).
+* See https://rubygems.org/gems/maxcdn/versions/0.2.1 for gem.
 
 ##### 0.1.5
 

--- a/lib/maxcdn.rb
+++ b/lib/maxcdn.rb
@@ -1,5 +1,4 @@
 require "signet/oauth_1/client"
-require "curb-fu"
 require "json"
 require "ext/hash"
 require "pp" # for debug
@@ -49,46 +48,32 @@ module MaxCDN
       request = @request_signer.generate_authenticated_request(req_opts)
 
       # crazyness for headers
-      headers = options.delete(:headers) || {}
+      headers = {"Content-Type" => options[:body] ? "application/json" : "application/x-www-form-urlencoded"}
+      headers.case_indifferent_merge(options.delete(:headers) || {})
       headers["User-Agent"] = "Ruby MaxCDN API Client"
-
-      # because CurbFu overwrites 'content-type' header, strip it
-      # to set it later
-      content_type = headers.case_indifferent_delete("Content-Type") || (options[:body] ? "application/json" : "application/x-www-form-urlencoded")
 
       # merge headers with request headers
       request.headers.case_indifferent_merge(headers)
 
       begin
-        curb_opts = {
-          :url => req_opts[:uri],
-          :headers => request.headers
-        }
+        url, path = req_opts[:uri].match(%r"^(https://[^/]+)(/.+)$")[1, 2]
+        conn = Faraday.new(:url => url) do |faraday|
+          faraday.adapter :net_http_persistent
+        end
 
-        CurbFu.debug = debug
-
-        response = CurbFu.send method, curb_opts, request.body do |curb|
-          curb.verbose = debug
-
-          # Because CurbFu overwrites the content-type header passed
-          # to it. so we'll be setting our own.
-          #
-          # First, remove any existing 'Content-Type' header.
-          curb.headers.case_indifferent_delete("Content-Type")
-
-          # Second, set 'Content-Type' to our desired value.
-          curb.headers["Content-Type"] = content_type
+        response = conn.send(method, path) do |req|
+          req.headers = request.headers
+          req.body = request.body
         end
 
         return response if options[:debug_request]
         pp response if debug
 
         response_json = JSON.load(response.body)
-
         return response_json if options[:debug_json]
         pp response_json if debug
 
-        unless response.success? or response.redirect?
+        unless response.success?
           error_message = response_json["error"]["message"]
           raise MaxCDN::APIException.new("#{response.status}: #{error_message}")
         end

--- a/lib/maxcdn/version.rb
+++ b/lib/maxcdn/version.rb
@@ -1,3 +1,3 @@
 module MaxCDN
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/maxcdn.gemspec
+++ b/maxcdn.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.email = "joshua@mervine.net"
   gem.authors = ["Joshua P. Mervine"]
   gem.add_dependency 'json' if RUBY_VERSION.start_with? "1.8"
-  gem.add_dependency 'signet', '~> 0.5.1'
-  gem.add_dependency 'curb-fu', '~> 0.6.2'
+  gem.add_dependency 'signet', '~> 0.7'
+  gem.add_dependency 'faraday', '~> 0.9'
+  gem.add_dependency 'net-http-persistent', '~> 2.9'
 end

--- a/test/maxcdn_test.rb
+++ b/test/maxcdn_test.rb
@@ -15,7 +15,6 @@ expected_headers = {
   'Authorization' => /.+/,
   'Cache-Control' => /.+/,
   'Content-Type'  => "application/json",
-  'Expect'        => /.*/,
   'User-Agent'    => "Ruby MaxCDN API Client"
 }
 
@@ -101,7 +100,7 @@ class Client < Minitest::Test
 
   def test__response_as_json_debug_request
     res = @max._response_as_json("post", "zones/pull.json", { :body => true, :debug_request => true }, { "foo"=> "bar", "bar" => "foo" })
-    assert_equal(CurbFu::Response::Base, res.class)
+    assert_equal(Faraday::Response, res.class)
   end
 
   def test_custom_header


### PR DESCRIPTION
Close https://github.com/MaxCDN/ruby-maxcdn/issues/8

### Problem
- As mentioned in https://github.com/MaxCDN/ruby-maxcdn/issues/8, curb-fu depends on C extensions, it can be hard to use at some environments.
- We use ruby-maxcdn in Sidekiq workers and observed `RuntimeError: select(): Bad file descriptor` in `curl/easy.rb:309:in 'http_delete'`
  - Sidekiq tasks uses threads.
  - [libcurl seems to have restrictions about multi-thread uses](https://curl.haxx.se/libcurl/c/curl_easy_init.html).

### Solution
Replace curb-fu with Faraday because ruby-maxcdn already have Faraday in dependencies through signet.