### PR TITLE
MaxCDN::APIException should subclass StandardError

### DIFF
--- a/lib/maxcdn.rb
+++ b/lib/maxcdn.rb
@@ -4,7 +4,7 @@ require "ext/hash"
 require "pp" # for debug
 
 module MaxCDN
-  class APIException < Exception
+  class APIException < StandardError
   end
 
   class Client


### PR DESCRIPTION
Pedantic, but I think the general expectation for Ruby devs is that custom exceptions subclass `StandardError` rather than `Exception`. The latter is typically reserved for system-level issues (out of memory, signals, etc), while the former is intended to be recoverable by the program itself. An unspecified `rescue` block will capture anything that subclasses `StandardError`, but if you subclass `Exception` it'll fall through.

https://ruby-doc.org/core-2.2.0/Exception.html
https://robots.thoughtbot.com/rescue-standarderror-not-exception