### PR TITLE
Update error handling

### DIFF
--- a/lib/maxcdn.rb
+++ b/lib/maxcdn.rb
@@ -74,7 +74,7 @@ module MaxCDN
           error_message = response_json["error"]["message"]
           raise MaxCDN::APIException.new("#{response.status}: #{error_message}")
         end
-      rescue TypeError
+      rescue TypeError, NoMethodError
         raise MaxCDN::APIException.new("#{response.status}: No information supplied by the server")
       end
 

--- a/lib/maxcdn.rb
+++ b/lib/maxcdn.rb
@@ -36,8 +36,12 @@ module MaxCDN
 
       req_opts = { method: method }
 
+      if data.class == Hash
+        data = data.to_params
+      end
+      
       req_opts[:uri]  = _get_url(uri, (options[:body] ? {} : data))
-      req_opts[:body] = data.to_params if options[:body]
+      req_opts[:body] = data if options[:body]
 
       request = @request_signer.generate_authenticated_request(req_opts)
 


### PR DESCRIPTION
Ruby raises NoMethodError type of error when response is empty. Tested.