### PR TITLE
hmac base64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ sudo: false
 before_install:
   - gem update bundler
 rvm:
-  - 2.3
-  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,46 +10,46 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
-    builder (3.2.3)
-    coderay (1.1.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
-    faraday (0.15.0)
+    builder (3.2.4)
+    coderay (1.1.3)
+    crack (0.4.5)
+      rexml
+    faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
-    hashdiff (0.3.7)
-    jwt (2.1.0)
-    method_source (0.9.0)
-    minitest (5.11.3)
-    minitest-reporters (1.2.0)
+    hashdiff (1.0.1)
+    jwt (2.2.3)
+    method_source (1.0.0)
+    minitest (5.14.4)
+    minitest-reporters (1.4.3)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    multi_json (1.13.1)
-    multipart-post (2.0.0)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
     net-http-persistent (2.9.4)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    public_suffix (3.0.2)
-    rake (12.3.1)
-    ruby-progressbar (1.9.0)
-    safe_yaml (1.0.4)
-    signet (0.8.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.6)
+    rake (13.0.3)
+    rexml (3.2.5)
+    ruby-progressbar (1.11.0)
+    signet (0.15.0)
       addressable (~> 2.3)
-      faraday (~> 0.9)
+      faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    webmock (3.4.1)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   maxcdn!
@@ -60,4 +60,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   2.2.20

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd ruby-maxcdn
 bundle install --path vendor/bundle
 
 # unit tests
-bundle exec ruby ./test/test.rb
+bundle exec ruby ./test/maxcdn_test.rb
 
 # integration tests
 export ALIAS=<your alias>

--- a/lib/maxcdn.rb
+++ b/lib/maxcdn.rb
@@ -1,3 +1,4 @@
+require "base64"
 require "signet/oauth_1/client"
 require "json"
 require "ext/hash"


### PR DESCRIPTION
Fixes

> NameError: uninitialized constant Signet::OAuth1::HMACSHA1::Base64

Also,

- Removes deprecated Rubies
- Updates Gemfile dependencies
- Fixes README instructions